### PR TITLE
Add allowMultiplesOf option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
   // Enable different colors for when values are correct multiples of spacer variable
   "sassSpacer.enableSensitiveColors": true,
   
-  // A multiple of spacer is considered correct if it's itself a multiple of this number
-  "sassSpacer.allowMultiplesOf": 1,
+  // A multiple of spacer is considered correct if the quotient of division by spacer is a multiple of this number
+  "sassSpacer.allowQuotientsMultipleOf": 1,
 
   // Decoration color for adequate values
   "sassSpacer.adequateValueColor": "#a3ea9d",

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 
   // Enable different colors for when values are correct multiples of spacer variable
   "sassSpacer.enableSensitiveColors": true,
+  
+  // With enableSensitiveColors, a factor of spacer is considered correct if it's a mutiple of this number
+  "sassSpacer.allowFactorsMultipleOf": 1,
 
   // Decoration color for adequate values
   "sassSpacer.adequateValueColor": "#a3ea9d",

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
   // Enable different colors for when values are correct multiples of spacer variable
   "sassSpacer.enableSensitiveColors": true,
   
-  // With enableSensitiveColors, a factor of spacer is considered correct if it's a mutiple of this number
-  "sassSpacer.allowFactorsMultipleOf": 1,
+  // A multiple of spacer is considered correct if it's itself a multiple of this number
+  "sassSpacer.allowMultiplesOf": 1,
 
   // Decoration color for adequate values
   "sassSpacer.adequateValueColor": "#a3ea9d",

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
           "default": true,
           "description": "Enable different colors for when values are correct multiples of spacer variable"
         },
-        "sassSpacer.allowFactorsMultipleOf": {
+        "sassSpacer.allowMultiplesOf": {
           "type": "number",
           "default": 1,
-          "description": "With enableSensitiveColors, a factor of spacer is considered correct if it's a mutiple of this number"
+          "description": "A multiple of spacer is considered correct if it's itself a multiple of this number"
         },
         "sassSpacer.spacer": {
           "type": "number",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
           "default": true,
           "description": "Enable different colors for when values are correct multiples of spacer variable"
         },
+        "sassSpacer.allowFactorsMultipleOf": {
+          "type": "number",
+          "default": 1,
+          "description": "With enableSensitiveColors, a factor of spacer is considered correct if it's a mutiple of this number"
+        },
         "sassSpacer.spacer": {
           "type": "number",
           "default": 8,

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
           "default": true,
           "description": "Enable different colors for when values are correct multiples of spacer variable"
         },
-        "sassSpacer.allowMultiplesOf": {
+        "sassSpacer.allowQuotientsMultipleOf": {
           "type": "number",
           "default": 1,
-          "description": "A multiple of spacer is considered correct if it's itself a multiple of this number"
+          "description": "A multiple of spacer is considered correct if the quotient of division by spacer is a multiple of this number"
         },
         "sassSpacer.spacer": {
           "type": "number",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ const {
   adequateValueColor,
   neutralColor,
   enableSensitiveColors,
-  allowFactorsMultipleOf,
+  allowMultiplesOf,
 } = configuration;
 
 export function activate() {
@@ -32,7 +32,7 @@ function processActiveFile(document) {
       const values = i.matches.map(m => {
         const value = m.value/spacer;
         msg += ` $spacer*${String(value)}`;
-        if (m.value % allowFactorsMultipleOf !== 0 && enableSensitiveColors) { color = inadequateValueColor; }
+        if (m.value % allowMultiplesOf !== 0 && enableSensitiveColors) { color = inadequateValueColor; }
       });
 
       decorate(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ const {
   adequateValueColor,
   neutralColor,
   enableSensitiveColors,
+  allowFactorsMultipleOf,
 } = configuration;
 
 export function activate() {
@@ -31,7 +32,7 @@ function processActiveFile(document) {
       const values = i.matches.map(m => {
         const value = m.value/spacer;
         msg += ` $spacer*${String(value)}`;
-        if (m.value % spacer !== 0 && enableSensitiveColors) { color = inadequateValueColor; }
+        if (m.value % allowFactorsMultipleOf !== 0 && enableSensitiveColors) { color = inadequateValueColor; }
       });
 
       decorate(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ const {
   adequateValueColor,
   neutralColor,
   enableSensitiveColors,
-  allowMultiplesOf,
+  allowQuotientsMultipleOf,
 } = configuration;
 
 export function activate() {
@@ -32,7 +32,7 @@ function processActiveFile(document) {
       const values = i.matches.map(m => {
         const value = m.value/spacer;
         msg += ` $spacer*${String(value)}`;
-        if (m.value % allowMultiplesOf !== 0 && enableSensitiveColors) { color = inadequateValueColor; }
+        if (m.value % allowQuotientsMultipleOf !== 0 && enableSensitiveColors) { color = inadequateValueColor; }
       });
 
       decorate(


### PR DESCRIPTION
This is useful in cases when you have a huge codebase, so it's not easy to change `$spacer` value, and later decides to allow some submultiples of `$spacer`, like half of it (e.g: `$spacer * 0.5`, `$spacer * 1.5`, etc).